### PR TITLE
Fixed issue, if PNG is not on last iteration.

### DIFF
--- a/Window.cpp
+++ b/Window.cpp
@@ -169,7 +169,7 @@ void keyPressed(int vk){
 				if (*format == *"PNG") {
 					index = i + 1;
 				}
-				else {
+				else if (index != 0) {
 					index = 0;
 				}
 			}


### PR DESCRIPTION
Previous commit added a bug, where if PNG was not on the last iteration, index would be set to 0.
